### PR TITLE
Allow setup of port forwarder by passing custom PortForward struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/gophercloud/gophercloud v0.0.0-20180807015416-4ea085781bae // indirect
 	github.com/imdario/mergo v0.3.5 // indirect
 	github.com/json-iterator/go v0.0.0-20180701071628-ab8a2e0c74be // indirect
-	github.com/justinbarrick/go-k8s-portforward v1.0.2
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
 	github.com/pkg/errors v0.8.0

--- a/portforward_test.go
+++ b/portforward_test.go
@@ -1,11 +1,12 @@
 package portforward
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakekubernetes "k8s.io/client-go/kubernetes/fake"
-	"testing"
 )
 
 func newPod(name string, labels map[string]string) *corev1.Pod {
@@ -58,7 +59,7 @@ func TestFindPodByLabelsNoneExist(t *testing.T) {
 
 	_, err := pf.findPodByLabels()
 	assert.NotNil(t, err)
-	assert.Equal(t, "Could not find pod for selector: labels \"name=flux\"", err.Error())
+	assert.Equal(t, "Could not find running pod for selector: labels \"name=flux\"", err.Error())
 }
 
 func TestFindPodByLabelsMultiple(t *testing.T) {
@@ -132,7 +133,7 @@ func TestFindPodByLabelsExpressionNotFound(t *testing.T) {
 
 	_, err := pf.findPodByLabels()
 	assert.NotNil(t, err)
-	assert.Equal(t, "Could not find pod for selector: labels \"name in (flux,fluxd)\"", err.Error())
+	assert.Equal(t, "Could not find running pod for selector: labels \"name in (flux,fluxd)\"", err.Error())
 }
 
 func TestGetPodNameNameSet(t *testing.T) {


### PR DESCRIPTION
NewPortForwarderCustom method should allow this. It's basically the same as NewPortForwarder, but by passing a pointer to a previously initialized PortForward struct.

Possible use case: when you know the name,namespace, destination port and listen port and just want to port-forward directly.

Under the current code, this is not possible, as either I would need to provide a labelSelector, which I don't need under this scenario, or I would have to construct everything by hand, having to import all sorts of packages to do it.

Also test updates, I suppose someone forgot to update the assertion strings and tests were failing.